### PR TITLE
Stop onload callback from mini_backend.js

### DIFF
--- a/mini_backend.js
+++ b/mini_backend.js
@@ -17,9 +17,9 @@ const backend = {
         return saveJSONToServer();
     }
 };
-window.onload = async function() {
-    downloadFromServer();
-}
+// window.onload = async function() {
+//     downloadFromServer();
+// }
 
 async function downloadFromServer() {
     let result = await loadJSONFromServer();


### PR DESCRIPTION
Creats confusion for users, as they try to read from jsonFromServer before it was donwloaded from Server.