### PR TITLE
fixed return message hint in console

### DIFF
--- a/mini_backend.js
+++ b/mini_backend.js
@@ -102,10 +102,11 @@ function saveJSONToServer() {
 
 function determineProxySettings() {
     return '';
-
+    /**
     if (window.location.href.indexOf('.developerakademie.com') > -1) {
         return '';
     } else {
         return 'https://cors-anywhere.herokuapp.com/';
     }
+    **/
 }


### PR DESCRIPTION
When using this backend, a message constantly pops up in the console that code is never reached after a return statement. By commenting out this section, no more messages should appear.